### PR TITLE
Fix pip software instructions

### DIFF
--- a/software.md
+++ b/software.md
@@ -13,7 +13,7 @@ Then install the Sense HAT software package:
 
 ```bash
 sudo apt-get install sense-hat
-sudo pip-3.2 install pillow
+sudo pip3 install pillow
 ```
 
 Finally, reboot the Pi to complete the installation:


### PR DESCRIPTION
Recent versions of Raspbian don't include pip-3.2, only pip3
